### PR TITLE
Use Rocky8 with Squid 4.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM centos:centos8
+FROM rockylinux:latest
 LABEL maintainer=StackHPC
 
-ENV SQUID_VERSION=4.4 \
+ENV SQUID_VERSION=4.15 \
     SQUID_CACHE_DIR=/var/spool/squid \
     SQUID_LOG_DIR=/var/log/squid \
     SQUID_USER=squid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:latest
+FROM rockylinux:8.6
 LABEL maintainer=StackHPC
 
 ENV SQUID_VERSION=4.15 \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stackhpc/squid:4.4-8
+# stackhpc/squid:4.15
 
 - [Introduction](#introduction)
   - [Contributing](#contributing)
@@ -53,13 +53,13 @@ If the above recommendations do not help then [report your issue](../../issues/n
 ## Installation
 
 ```bash
-docker pull stackhpc/squid:4.4-8
+docker pull stackhpc/squid:4.15
 ```
 
 Alternatively you can build the image yourself.
 
 ```bash
-docker build -t stackhpc/squid:4.4-8 github.com/stackhpc/docker-squid
+docker build -t stackhpc/squid:4.15 github.com/stackhpc/docker-squid
 ```
 
 ## Quickstart
@@ -71,7 +71,7 @@ docker run --name squid -d --restart=always \
   --publish 3128:3128 \
   --volume /srv/docker/squid/log:/var/log/squid \
   --volume /srv/docker/squid/cache:/var/spool/squid \
-  stackhpc/squid:4.4-8
+  stackhpc/squid:4.15
 ```
 
 *Alternatively, you can use the sample [docker-compose.yml](docker-compose.yml) file to start the container using [Docker Compose](https://docs.docker.com/compose/)*
@@ -85,7 +85,7 @@ docker run --name squid -it --rm \
   --publish 3128:3128 \
   --volume /srv/docker/squid/log:/var/log/squid \
   --volume /srv/docker/squid/cache:/var/spool/squid \
-  stackhpc/squid:4.4-8 -h
+  stackhpc/squid:4.15 -h
 ```
 
 ## Persistence
@@ -110,7 +110,7 @@ docker run --name squid -d --restart=always \
   --publish 3128:3128 \
   --volume /path/to/squid.conf:/etc/squid/squid.conf \
   --volume /srv/docker/squid/cache:/var/spool/squid \
-  stackhpc/squid:4.4-8
+  stackhpc/squid:4.15
 ```
 
 To reload the Squid configuration on a running instance you can send the `HUP` signal to the container.
@@ -158,7 +158,7 @@ To upgrade to newer releases:
   1. Download the updated Docker image:
 
   ```bash
-  docker pull stackhpc/squid:4.4-8
+  docker pull stackhpc/squid:4.15
   ```
 
   2. Stop the currently running image:
@@ -178,7 +178,7 @@ To upgrade to newer releases:
   ```bash
   docker run -name squid -d \
     [OPTIONS] \
-    stackhpc/squid:4.4-8
+    stackhpc/squid:4.15
   ```
 
 ## Shell Access

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Based on the Squid container by [sameersbn](https://github.com/sameersbn/docker-
 - Uses a disk cache (4 GB) in `/var/spool/squid`
 - Configures for logging to files under `/var/log/squid`
 - Raises the RAM cache to 768 MB (default is 256 MB)
-- Raises the maximum object size to 16 MB (default is 512 KB)
+- Raises the maximum object size to 64 MB (default is 512 KB)
 
 ## Contributing
 

--- a/squid.conf
+++ b/squid.conf
@@ -61,7 +61,7 @@ http_port 3128
 # Uncomment and adjust the following to add a disk cache directory.
 cache_dir ufs /var/spool/squid 4096 16 256
 cache_mem 768 MB
-maximum_object_size_in_memory 32 MB
+maximum_object_size_in_memory 64 MB
 
 # Leave coredumps in the first cache dir
 coredump_dir /var/spool/squid


### PR DESCRIPTION
- Uses Rocky base image
- Bumps squid version to that available in Rocky Linux 8.6
- Bumps max object size to make it more useful as a yum/dnf cache
